### PR TITLE
Removed the repeated color codes.

### DIFF
--- a/ascii_magic/_ascii_magic.py
+++ b/ascii_magic/_ascii_magic.py
@@ -218,6 +218,7 @@ class AsciiArt:
             grayscale_img.save('grayscale.jpg')
 
         lines = []
+        previousColor = ''
         for h in range(img_h):
             line = ''
 
@@ -231,8 +232,9 @@ class AsciiArt:
 
                 srgb = [(v/255.0)**2.2 for v in pixel]
                 char = chars[int(brightness * (len(chars) - 1))]
-                line += self._build_char(char, srgb, brightness, mode, front)
-
+                coloredChar = self._build_char(char, srgb, brightness, previousColor, mode, front)
+                line += coloredChar
+                previousColor = coloredChar[0:-1]
             if mode == Modes.TERMINAL and front:
                 line = str(front) + line + colorama.Fore.RESET
             if mode == Modes.TERMINAL and back:
@@ -272,6 +274,7 @@ class AsciiArt:
         char: str,
         srgb: list,
         brightness: float,
+        previousColor: str,
         mode: Modes = Modes.TERMINAL,
         front: Optional[Front] = None,
     ) -> str:
@@ -281,6 +284,8 @@ class AsciiArt:
             if front:
                 return char  # Front color will be set per-line
             else:
+                if color['term'] == previousColor:
+                    return char
                 return color['term'] + char
 
         elif mode == Modes.ASCII:

--- a/ascii_magic/_ascii_magic.py
+++ b/ascii_magic/_ascii_magic.py
@@ -234,7 +234,8 @@ class AsciiArt:
                 char = chars[int(brightness * (len(chars) - 1))]
                 coloredChar = self._build_char(char, srgb, brightness, previousColor, mode, front)
                 line += coloredChar
-                previousColor = coloredChar[0:-1]
+                if len(coloredChar) > 1:
+                    previousColor = coloredChar[0:-1]
             if mode == Modes.TERMINAL and front:
                 line = str(front) + line + colorama.Fore.RESET
             if mode == Modes.TERMINAL and back:


### PR DESCRIPTION
When writing color codes in the terminal and saving them into a file, you don't need to rewrite the color code again if it's the same as before.
The way  code worked previously is as follow:
 Suppose we have a line with ten "a" characters in red color and three "." characters in blue color. It is represented in the following format:
_\<red\>a\<red\>a\<red\>a\<red\>a\<red\>a\<red\>a\<red\>a\<red\>a\<red\>a\<blue\>.\<blue\>.\<blue\>._

However, this can also be written as:
_\<red\>aaaaaaaaaa\<blue\>..._

Doing so will help to print large output to terminal quickly.
When I saved the output of the same image with the same number columns to a file and then  used `wc` to count the lines, words, and characters. The output is as follows:
```
[spd@DELL ascii_magic]$ wc old.txt
283 64511 852288 old.txt
[spd@DELL ascii_magic]$ wc new.txt
283 32516 506143 new.txt
```
Number of characters is less by 1.68 times in this case.

I have tested this on my linux machine. I don't have windows. But should work on windows too.