### PR TITLE
add opening html tag to match the closing tag

### DIFF
--- a/ascii_magic/ascii_art.py
+++ b/ascii_magic/ascii_art.py
@@ -556,6 +556,7 @@ class AsciiArt:
         auto_open: bool = False,
     ) -> None:
         html = f"""<!DOCTYPE html>
+    <html>
     <head>
         <title>ASCII art</title>
         <meta name="generator" content="ASCII Magic {AsciiArt.__VERSION__} - https://github.com/LeandroBarone/python-ascii_magic/" />

--- a/ascii_magic/tests/test_from_swarmui.py
+++ b/ascii_magic/tests/test_from_swarmui.py
@@ -4,7 +4,7 @@ import pytest
 import os
 
 
-def test_from_swamui():
+def test_from_swarmui():
     if not os.environ.get('SWARMUI_SERVER'):
         pytest.skip('No SwarmUI server found on environment (KEY=SWARMUI_SERVER)')
 

--- a/ascii_magic/tests/test_from_swarmui.py
+++ b/ascii_magic/tests/test_from_swarmui.py
@@ -8,7 +8,7 @@ def test_from_swamui():
     if not os.environ.get('SWARMUI_SERVER'):
         pytest.skip('No SwarmUI server found on environment (KEY=SWARMUI_SERVER)')
 
-    my_art = AsciiArt.from_swamui(
+    my_art = AsciiArt.from_swarmui(
         'A hyperrealistic portrait of a cow with noble clothes, digital art',
         raw_input={
             'width': 1344,


### PR DESCRIPTION
Quick PR for adding the opening `<html>` tag when exporting to HTML files. Browsers can infer it but other custom HTML parsers have a hard time with this